### PR TITLE
fix Git submodule cloning failure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ft8_lib"]
 	path = ft8_lib
-	url = git://github.com/kgoba/ft8_lib
+	url = https://github.com/kgoba/ft8_lib.git


### PR DESCRIPTION
Observed this during image build:

```
Submodule 'ft8_lib' (git://github.com/kgoba/ft8_lib) registered for path 'ft8_lib'
Cloning into '/root/rtlsdr_ft8d/ft8_lib'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/kgoba/ft8_lib' into submodule path '/root/rtlsdr_ft8d/ft8_lib' failed
Failed to clone 'ft8_lib'. Retry scheduled
Cloning into '/root/rtlsdr_ft8d/ft8_lib'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/kgoba/ft8_lib' into submodule path '/root/rtlsdr_ft8d/ft8_lib' failed
Failed to clone 'ft8_lib' a second time, aborting
```
